### PR TITLE
feat(adac-core): added pre release script to setup icons prebuild

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,13 +65,13 @@ packages/*/mappings/
 *.pptx
 
 # Exceptions: Allow source icons (AWS/Azure/GCP) to be committed
-!packages/icons-*/assets/
-!packages/icons-*/assets/**
-!packages/icons-*/mappings/
-!packages/icons-*/mappings/**
+# !packages/icons-*/assets/
+# !packages/icons-*/assets/**
+# !packages/icons-*/mappings/
+# !packages/icons-*/mappings/**
 
 # Exceptions: Allow web public assets
-!packages/web/public/*.svg
+# !packages/web/public/*.svg
 !packages/web/public/*.png
 !packages/web/public/*.jpg
 

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "prepare": "husky",
     "cli": "node packages/diagram/dist/cli.js",
     "setup:icons": "pnpm --filter @mindfiredigital/adac-icons-aws run setup-icons && pnpm --filter @mindfiredigital/adac-icons-gcp run setup-icons && pnpm --filter @mindfiredigital/adac-icons-azure run setup-icons",
+    "prerelease:pack": "pnpm setup:icons && pnpm build",
     "release:pack": "node scripts/pack-release.js",
     "release:publish": "node scripts/publish-packages.mjs",
     "release:publish:dry-run": "node scripts/publish-packages.mjs --dry-run",


### PR DESCRIPTION
This PR improves the release and build workflow by automating the icon generation process and ensuring that generated assets are excluded from version control. By introducing a new `prerelease:pack` script, we guarantee that all icon assets are correctly initialized and built before any package distribution.

### Key Changes

#### 1. Build Workflow Automation (`package.json`)
- **Added `prerelease:pack` script:** Introduced `"prerelease:pack": "pnpm setup:icons && pnpm build"`.
- **Purpose:** This ensures that whenever a release package is prepared, the icons are first set up (`setup:icons`) and then the project is built. This prevents issues where published packages might be missing generated icon assets.

#### 2. Clean Version Control (`.gitignore`)
- **Updated Icon Asset Rules:** Commented out several `!` (negation) rules that were previously forcing Git to track generated icon files.
- **Affected Paths:**
    - `packages/icons-*/assets/`
    - `packages/icons-*/mappings/`
    - `packages/web/public/*.svg`
- **Purpose:** Since these files are now automatically generated during the build process, they no longer need to be committed to the repository. This reduces repository size and keeps the commit history focused on source code changes.

### Why this is needed?
Currently, the build process relies on icons being manually set up. If a developer forgets to run `setup:icons` before a release, the resulting package could be broken. Additionally, tracking generated SVGs in Git creates unnecessary "noise" in PRs.

### Testing Plan
1. Run `pnpm prerelease:pack` and verify that icons are generated and the build completes successfully.
2. Verify that changes to generated icon files are ignored by Git (no longer appearing in `git status`).
