### PR TITLE
chore(deps): add ts-node to devDependencies in icons-aws and icons-gcp

### DIFF
--- a/packages/icons-aws/package.json
+++ b/packages/icons-aws/package.json
@@ -30,7 +30,8 @@
     "directory": "packages/icons-aws"
   },
   "devDependencies": {
-    "vitest": "^4.0.18"
+    "vitest": "^4.0.18",
+    "ts-node": "^10.9.2"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/icons-gcp/package.json
+++ b/packages/icons-gcp/package.json
@@ -30,7 +30,8 @@
     "directory": "packages/icons-gcp"
   },
   "devDependencies": {
-    "vitest": "^4.0.18"
+    "vitest": "^4.0.18",
+    "ts-node": "^10.9.2"
   },
   "publishConfig": {
     "access": "public",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -348,6 +348,9 @@ importers:
 
   packages/icons-aws:
     devDependencies:
+      ts-node:
+        specifier: ^10.9.2
+        version: 10.9.2(@types/node@25.3.0)(typescript@5.9.3)
       vitest:
         specifier: ^4.0.18
         version: 4.0.18(@edge-runtime/vm@3.2.0)(@types/node@25.3.0)(@vitest/ui@4.1.1)(jiti@2.6.1)(jsdom@29.0.1(@noble/hashes@1.8.0))(tsx@4.21.0)(yaml@2.8.3)
@@ -381,6 +384,9 @@ importers:
 
   packages/icons-gcp:
     devDependencies:
+      ts-node:
+        specifier: ^10.9.2
+        version: 10.9.2(@types/node@25.3.0)(typescript@5.9.3)
       vitest:
         specifier: ^4.0.18
         version: 4.0.18(@edge-runtime/vm@3.2.0)(@types/node@25.3.0)(@vitest/ui@4.1.1)(jiti@2.6.1)(jsdom@29.0.1(@noble/hashes@1.8.0))(tsx@4.21.0)(yaml@2.8.3)


### PR DESCRIPTION
## Description

This PR adds `ts-node` to the `devDependencies` of both `icons-aws` and `icons-gcp` packages to resolve the `setup-icons` CI build failure.